### PR TITLE
Mac and non-GPU support

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10']
 
     steps:
       - uses: actions/checkout@v3

--- a/LICENSE
+++ b/LICENSE
@@ -2,9 +2,11 @@
 Copyright (c) 2024, Brian Northan
 All rights reserved.
 
-This work re-uses some code from  napari sam (see license here https://github.com/MIC-DKFZ/napari-sam/blob/main/LICENSE)
+This work re-uses some code from the following sources:
+- napari sam (License: https://github.com/MIC-DKFZ/napari-sam/blob/main/LICENSE)
+- napari-segment-anything (License: https://github.com/royerlab/napari-segment-anything/blob/main/LICENSE)  
+- MobileSAMv2 (License: https://github.com/ChaoningZhang/MobileSAM/blob/master/LICENSE)
 
-And also re-uses some code from  napari-segment-anything (see license here https://github.com/royerlab/napari-segment-anything/blob/main/LICENSE)  
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/LICENSE
+++ b/LICENSE
@@ -7,6 +7,7 @@ This work re-uses some code from the following sources:
 - napari-segment-anything (License: https://github.com/royerlab/napari-segment-anything/blob/main/LICENSE)  
 - MobileSAMv2 (License: https://github.com/ChaoningZhang/MobileSAM/blob/master/LICENSE)
 
+Additionally, training data is from Cellpose's annotated dataset, which is licensed CC-by-NC (see: https://github.com/MouseLand/cellpose?tab=readme-ov-file)
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/src/napari_segment_everything/_tests/test_mobile_sam.py
+++ b/src/napari_segment_everything/_tests/test_mobile_sam.py
@@ -17,6 +17,8 @@ import os
 import requests
 from gdown.parse_url import parse_url
 
+device = get_device()
+
 
 def test_urls():
     """
@@ -39,7 +41,7 @@ def test_urls():
             print(f"Request timed out for URL: {url}")
 
 
-def test_mobile_sam():
+def test_mobile_sam(device):
     """
     Tests the mobileSAMv2 process pipeline
     """
@@ -50,59 +52,51 @@ def test_mobile_sam():
         image,
         detector_model="YOLOv8",
         imgsz=1024,
-        device="cuda",
+        device=device,
         conf=0.4,
         iou=0.9,
     )
-    segmentations = get_mobileSAMv2(image, bounding_boxes)
+    segmentations = get_mobileSAMv2(image, bounding_boxes, device)
 
     assert len(segmentations) == 11
 
 
-def test_bbox():
+def test_bbox(device):
     """
     Test whether bboxes can be generated
     """
     image = data.coffee()
     bounding_boxes = get_bounding_boxes(
-        image, detector_model="Finetuned", device="cuda", conf=0.01, iou=0.99
+        image, detector_model="Finetuned", device=device, conf=0.01, iou=0.99
     )
     print(f"Length of bounding boxes: {len(bounding_boxes)}")
     assert len(bounding_boxes) > 0
 
 
-def test_RCNN():
+def test_RCNN(device):
     """
     Test RCNN object detection on CPU and CUDA devices.
     """
     image = data.coffee()
     model_path = str(get_weights_path("ObjectAwareModel_Cell_FT"))
     assert os.path.exists(model_path)
-    rcnn_cpu = RcnnDetector(model_path, device="cpu")
-    rcnn_cuda = RcnnDetector(model_path, device="cuda")
-    bbox_cpu = rcnn_cpu.get_bounding_boxes(image, conf=0.5, iou=0.2)
-    bbox_cuda = rcnn_cuda.get_bounding_boxes(image, conf=0.5, iou=0.2)
-    assert len(bbox_cpu) == 6
-    assert len(bbox_cuda) == 6
+    rcnn = RcnnDetector(model_path, device=device)
+    bbox = rcnn.get_bounding_boxes(image, conf=0.5, iou=0.2)
+    assert len(bbox) == 6
 
 
-def test_YOLO():
+def test_YOLO(device):
     """
     Test YOLO object detection on CPU and CUDA devices.
     """
     image = data.coffee()
     model_path = str(get_weights_path("ObjectAwareModel"))
     assert os.path.exists(model_path)
-    yolo_cpu = YoloDetector(model_path, device="cpu")
-    yolo_cuda = YoloDetector(model_path, device="cuda")
-    bbox_cpu = yolo_cpu.get_bounding_boxes(
+    yolo = YoloDetector(model_path, device=device)
+    bbox = yolo.get_bounding_boxes(
         image, conf=0.5, iou=0.2, max_det=400, imgsz=1024
     )
-    bbox_cuda = yolo_cuda.get_bounding_boxes(
-        image, conf=0.5, iou=0.2, max_det=400, imgsz=1024
-    )
-    assert len(bbox_cpu) == 8
-    assert len(bbox_cuda) == 8
+    assert len(bbox) == 8
 
 
 def test_weights_path():
@@ -113,12 +107,11 @@ def test_weights_path():
     assert os.path.exists(os.path.dirname(weights_path))
 
 
-def test_labels():
+def test_labels(device):
     """
     Tests whether region properties can be generated for segmentations for different models
     """
     image = data.coffee()
-    device = get_device()
 
     bbox_yolo = get_bounding_boxes(
         image,
@@ -161,9 +154,9 @@ def test_labels():
 
 
 test_urls()
-test_bbox()
-test_mobile_sam()
-test_RCNN()
-test_YOLO()
+test_bbox(device)
+test_mobile_sam(device)
+test_RCNN(device)
+test_YOLO(device)
 test_weights_path()
-test_labels()
+test_labels(device)

--- a/src/napari_segment_everything/_tests/test_mobile_sam.py
+++ b/src/napari_segment_everything/_tests/test_mobile_sam.py
@@ -20,15 +20,23 @@ from gdown.parse_url import parse_url
 
 def test_urls():
     """
-    Tests whether all the urls for the model weights exist.
+    Tests whether all the urls for the model weights exist and are accessible.
     """
-    for url in SAM_WEIGHTS_URL.values():
-        if url.startswith("https://drive.google.com/"):
-            _, path_exists = parse_url(url)
-            assert path_exists
-        else:
-            req = requests.head(url)
-            assert req.status_code == 200
+    TIMEOUT = 1
+    for name, url in SAM_WEIGHTS_URL.items():
+        try:
+            if url.startswith("https://drive.google.com/"):
+                _, path_exists = parse_url(url)
+                assert (
+                    path_exists
+                ), f"Google Drive URL path wasn't parsed correctly: {url}"
+            else:
+                req = requests.head(url, timeout=TIMEOUT)
+                assert (
+                    req.status_code == 200
+                ), f"Failed to access URL: {url}, Status code: {req.status_code}"
+        except requests.exceptions.Timeout:
+            print(f"Request timed out for URL: {url}")
 
 
 def test_mobile_sam():

--- a/src/napari_segment_everything/_tests/test_mobile_sam.py
+++ b/src/napari_segment_everything/_tests/test_mobile_sam.py
@@ -41,7 +41,7 @@ def test_urls():
             print(f"Request timed out for URL: {url}")
 
 
-def test_mobile_sam(device):
+def test_mobile_sam():
     """
     Tests the mobileSAMv2 process pipeline
     """
@@ -61,7 +61,7 @@ def test_mobile_sam(device):
     assert len(segmentations) == 11
 
 
-def test_bbox(device):
+def test_bbox():
     """
     Test whether bboxes can be generated
     """
@@ -73,7 +73,7 @@ def test_bbox(device):
     assert len(bounding_boxes) > 0
 
 
-def test_RCNN(device):
+def test_RCNN():
     """
     Test RCNN object detection on CPU and CUDA devices.
     """
@@ -85,7 +85,7 @@ def test_RCNN(device):
     assert len(bbox) == 6
 
 
-def test_YOLO(device):
+def test_YOLO():
     """
     Test YOLO object detection on CPU and CUDA devices.
     """
@@ -107,7 +107,7 @@ def test_weights_path():
     assert os.path.exists(os.path.dirname(weights_path))
 
 
-def test_labels(device):
+def test_labels():
     """
     Tests whether region properties can be generated for segmentations for different models
     """
@@ -154,9 +154,9 @@ def test_labels(device):
 
 
 test_urls()
-test_bbox(device)
-test_mobile_sam(device)
-test_RCNN(device)
-test_YOLO(device)
+test_bbox()
+test_mobile_sam()
+test_RCNN()
+test_YOLO()
 test_weights_path()
-test_labels(device)
+test_labels()

--- a/src/napari_segment_everything/_tests/test_mobile_sam.py
+++ b/src/napari_segment_everything/_tests/test_mobile_sam.py
@@ -18,6 +18,8 @@ import requests
 from gdown.parse_url import parse_url
 
 device = get_device()
+if device == "mps":
+    device = "cpu"
 
 #%%
 def test_urls():
@@ -67,7 +69,7 @@ def test_bbox():
     """
     image = data.coffee()
     bounding_boxes = get_bounding_boxes(
-        image, detector_model="YOLOv8", device=device, conf=0.5, iou=0.90
+        image, detector_model="YOLOv8", device=device, conf=0.9, iou=0.90
     )
     print(f"Length of bounding boxes: {len(bounding_boxes)}")
     assert len(bounding_boxes) > 0

--- a/src/napari_segment_everything/_tests/test_mobile_sam.py
+++ b/src/napari_segment_everything/_tests/test_mobile_sam.py
@@ -67,7 +67,7 @@ def test_bbox():
     """
     image = data.coffee()
     bounding_boxes = get_bounding_boxes(
-        image, detector_model="YOLOv8", device=device, conf=0.01, iou=0.99
+        image, detector_model="YOLOv8", device=device, conf=0.5, iou=0.90
     )
     print(f"Length of bounding boxes: {len(bounding_boxes)}")
     assert len(bounding_boxes) > 0

--- a/src/napari_segment_everything/_tests/test_mobile_sam.py
+++ b/src/napari_segment_everything/_tests/test_mobile_sam.py
@@ -19,7 +19,7 @@ from gdown.parse_url import parse_url
 
 device = get_device()
 
-
+#%%
 def test_urls():
     """
     Tests whether all the urls for the model weights exist and are accessible.
@@ -56,7 +56,7 @@ def test_mobile_sam():
         conf=0.4,
         iou=0.9,
     )
-    segmentations = get_mobileSAMv2(image, bounding_boxes, device)
+    segmentations = get_mobileSAMv2(image, bounding_boxes)
 
     assert len(segmentations) == 11
 
@@ -67,7 +67,7 @@ def test_bbox():
     """
     image = data.coffee()
     bounding_boxes = get_bounding_boxes(
-        image, detector_model="Finetuned", device=device, conf=0.01, iou=0.99
+        image, detector_model="YOLOv8", device=device, conf=0.01, iou=0.99
     )
     print(f"Length of bounding boxes: {len(bounding_boxes)}")
     assert len(bounding_boxes) > 0
@@ -151,8 +151,7 @@ def test_labels():
     assert len(props_yolo) == 10
     props_vit_b = segmentations_vit_b[0].keys()
     assert len(props_vit_b) == 13
-
-
+    
 test_urls()
 test_bbox()
 test_mobile_sam()

--- a/src/napari_segment_everything/minimal_detection/detect_and_segment.py
+++ b/src/napari_segment_everything/minimal_detection/detect_and_segment.py
@@ -35,7 +35,7 @@ def batch_iterator(batch_size: int, *args) -> Generator[List[Any], None, None]:
         yield [arg[b * batch_size : (b + 1) * batch_size] for arg in args]
 
 
-def segment_from_bbox(bounding_boxes, predictor, mobilesamv2):
+def segment_from_bbox(bounding_boxes, predictor, mobilesamv2, device):
     """
     Segments everything given the bounding boxes of the objects and the mobileSAMv2 prediction model.
     Code from mobileSAMv2
@@ -43,7 +43,10 @@ def segment_from_bbox(bounding_boxes, predictor, mobilesamv2):
     input_boxes = predictor.transform.apply_boxes(
         bounding_boxes, predictor.original_size
     )  # Does this need to be transformed?
-    input_boxes = torch.from_numpy(input_boxes).cuda()
+    if device == "cuda":
+        input_boxes = torch.from_numpy(input_boxes).cuda()
+    elif device == "cpu":
+        input_boxes = torch.from_numpy(input_boxes)
     sam_mask = []
 
     predicted_ious = []

--- a/src/napari_segment_everything/minimal_detection/prompt_generator.py
+++ b/src/napari_segment_everything/minimal_detection/prompt_generator.py
@@ -109,8 +109,8 @@ class RcnnDetector(BaseDetector):
     def __init__(self, model_path, device, trainable=True):
         super().__init__(model_path, trainable)
         self.model_type = "FasterRCNN"
-	if device == "mps":
-        	device = "cpu"
+        if device == "mps":
+            device = "cpu"
         self.device = device
         self.model = fasterrcnn_mobilenet_v3_large_fpn(
             box_detections_per_img=500,

--- a/src/napari_segment_everything/minimal_detection/prompt_generator.py
+++ b/src/napari_segment_everything/minimal_detection/prompt_generator.py
@@ -109,11 +109,13 @@ class RcnnDetector(BaseDetector):
     def __init__(self, model_path, device, trainable=True):
         super().__init__(model_path, trainable)
         self.model_type = "FasterRCNN"
+	if device == "mps":
+        	device = "cpu"
         self.device = device
         self.model = fasterrcnn_mobilenet_v3_large_fpn(
             box_detections_per_img=500,
-        ).to(device)
-        self.model.load_state_dict(torch.load(model_path))
+        ).to(self.device)
+        self.model.load_state_dict(torch.load(model_path, map_location=self.device))
 
     def train(self, training_data):
         if self.trainable:

--- a/src/napari_segment_everything/sam_helper.py
+++ b/src/napari_segment_everything/sam_helper.py
@@ -178,7 +178,7 @@ def get_bounding_boxes(
     return bounding_boxes
 
 
-def get_mobileSAMv2(image=None, bounding_boxes=None):
+def get_mobileSAMv2(image=None, bounding_boxes=None, device=get_device()):
     """
     Uses a SAM model to make predictions from bounding boxes.
 
@@ -201,7 +201,6 @@ def get_mobileSAMv2(image=None, bounding_boxes=None):
         return
     if image.ndim < 3:
         image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
-    device = "cuda" if torch.cuda.is_available() else "cpu"
     # device = "cpu"
     weights_path_VIT = get_weights_path("efficientvit_l2")
     samV2 = create_MS_model()
@@ -213,7 +212,9 @@ def get_mobileSAMv2(image=None, bounding_boxes=None):
     samV2.eval()
     predictor = SamPredictorV2(samV2)
     predictor.set_image(image)
-    sam_masks = segment_from_bbox(bounding_boxes, predictor, samV2)
+    sam_masks = segment_from_bbox(
+        bounding_boxes, predictor, samV2, device=device
+    )
     del bounding_boxes
 
     gc.collect()
@@ -304,7 +305,7 @@ def add_properties_to_label_image(orig_image, sorted_results):
         # for small pixelated objects, circularity can be > 1 so we cap it
         if result["circularity"] > 1:
             result["circularity"] = 1
-            
+
         result["solidity"] = regions[0].solidity
         intensity_pixels = intensity[coords]
         result["mean_intensity"] = np.mean(intensity_pixels)

--- a/src/napari_segment_everything/sam_helper.py
+++ b/src/napari_segment_everything/sam_helper.py
@@ -132,8 +132,11 @@ def get_sam_automatic_mask_generator(
     crop_n_layers=1,
 ):
 
+    device = get_device()
+    if device == "mps":
+        device = "cpu"
     sam = sam_model_registry[model_type](get_weights_path(model_type))
-    sam.to(get_device())
+    sam.to()
     sam_anything_predictor = SamAutomaticMaskGenerator(
         sam,
         points_per_side=int(points_per_side),
@@ -208,6 +211,8 @@ def get_mobileSAMv2(image=None, bounding_boxes=None, device=get_device()):
     samV2.image_encoder = sam_model_registry["efficientvit_l2"](
         weights_path_VIT
     )
+    if device == "mps":
+        device="cpu"
     samV2.to(device=device)
     samV2.eval()
     predictor = SamPredictorV2(samV2)

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ PLATFORM =
     windows-latest: windows
 
 [testenv]
+setenv = 
+    PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0
 platform =
     macos: darwin
     linux: linux

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ isolated_build=true
 
 [gh-actions]
 python =
-    3.8: py38
+#    3.8: py38
     3.9: py39
     3.10: py310
 
@@ -16,8 +16,6 @@ PLATFORM =
     windows-latest: windows
 
 [testenv]
-setenv = 
-    PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0
 platform =
     macos: darwin
     linux: linux


### PR DESCRIPTION
Managed to pass all of our tests locally on my Mac :).

Some functions work with MPS support, whereas others don't. For the ones that don't, I elected to just pass to the calculations to the CPU. 
1) The model Faster_RCNN fails because of non-implemented pytorch function, as well as the MobileSAMv2 model (aten::upsample_bicubic2d.out)
2) SAM_Automatic_Mask_Generation fails because of floating point transformations. I think this is just caused by numpy defaulting to 64-bit precision, because SAM prediction works when we're just working with one mask at a time.

But what works is the YOLOv8 bounding box prediction, which is a pretty big step in our model.

Also, updating license to include mobileSAMv2 and the Cellpose dataset. 

Partially resolves #5 